### PR TITLE
Stop further processing when autoprogressing into the next tree

### DIFF
--- a/scripts/00.download_ingest_samples.py
+++ b/scripts/00.download_ingest_samples.py
@@ -59,8 +59,10 @@ def download_logs_interactive(url, repo_key, auth, path):
         selected_item = sorted_items[0]
         if selected_item['name'].endswith(".zip"):
             download_and_unzip_file(f"{url}/{repo_key}/{selected_item['path']}", auth, selected_item['name'])
+            return
         else:
             download_logs_interactive(url, repo_key, auth, selected_item['path'])
+            return
 
     for idx, file in enumerate(sorted_items, 1):
         print(f"[{idx}] {file['path']}")


### PR DESCRIPTION
Previously, when the CLI would automatically progress into the next tree element via recursion, when it returned from completing the first download, it would fall into the lower multiple choice block to ask the user what to do next. After answering enough questions, the CLI would naturally exit, but we can easily and reasonably skip asking these questions in the first place as per the intent of the original feature.