### PR TITLE
Add Branch to scatter plot output

### DIFF
--- a/scripts/02.embed_summaries_and_cluster.py
+++ b/scripts/02.embed_summaries_and_cluster.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         y="y",
         log_x=False,
         # hover_name=["Path"],
-        hover_data=["Path", "Extracted logs with line break"],
+        hover_data=["Path", "Branch", "Extracted logs with line break"],
         symbol="build",
         color="kmeans_summary",
         category_orders={"kmeans_summary": [str(i) for i in range(best_k)]},


### PR DESCRIPTION
When there are multiple branches ingested, having the branch within the scatter plot output makes it easier to identify where the error is at for more detailed investigation.